### PR TITLE
[Feature/15] 팀 목표 추가 API 구현 및 테스트

### DIFF
--- a/src/controllers/goal-controller.js
+++ b/src/controllers/goal-controller.js
@@ -41,3 +41,38 @@ exports.getUserGoals = async (req, res, next) => {
       .json({ error: 'Internal Server Error' });
   }
 };
+
+// 작성자: Minjae Han
+
+const { createGoal } = require('../services/goal-service');
+
+exports.createGoal = async (req, res, next) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ error: '유효하지 않은 사용자 ID입니다.' });
+    }
+
+    const { title, startDate, endDate, type, validationType } = req.body;
+
+    // 필수 필드 검증
+    if (!title || !startDate || !endDate || !type || !validationType) {
+      return res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ error: '유효하지 않은 요청입니다.' });
+    }
+
+    const goalData = req.body;
+    goalData.userId = userId;
+
+    const newGoal = await createGoal(goalData);
+    res.status(StatusCodes.CREATED).json(newGoal);
+  } catch (err) {
+    console.error('목표 추가 API 에러: ', err);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ error: 'Internal Server Error' });
+  }
+};

--- a/src/models/goal-model.js
+++ b/src/models/goal-model.js
@@ -33,3 +33,107 @@ exports.getUserGoals = async (userId) => {
     throw err;
   }
 };
+
+// 작성자: Minjae Han
+
+exports.createPersonalGoal = async (goalData) => {
+  const query = `
+    INSERT INTO Goals (user_id, title, description, start_date, end_date, type, validation_type, latitude, longitude, emoji, donation_organization_id, donation_amount)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `;
+
+  const values = [
+    goalData.userId,
+    goalData.title,
+    goalData.description,
+    goalData.startDate,
+    goalData.endDate,
+    goalData.type,
+    goalData.validationType,
+    goalData.latitude,
+    goalData.longitude,
+    goalData.emoji,
+    goalData.donationOrganizationId,
+    goalData.donationAmount,
+  ];
+
+  const [result] = await pool.execute(query, values);
+  return { id: result.insertId, ...goalData };
+};
+
+exports.createTeamGoal = async (goalData) => {
+  const connection = await pool.getConnection();
+  try {
+    await connection.beginTransaction();
+
+    // Goals 테이블에 기본 목표 정보 삽입
+    const [goalResult] = await connection.execute(
+      `
+      INSERT INTO Goals (user_id, title, description, start_date, end_date, type, validation_type, latitude, longitude, emoji, donation_organization_id, donation_amount)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      [
+        goalData.userId,
+        goalData.title,
+        goalData.description,
+        goalData.startDate,
+        goalData.endDate,
+        goalData.type,
+        goalData.validationType,
+        goalData.latitude,
+        goalData.longitude,
+        goalData.emoji,
+        goalData.donationOrganizationId,
+        goalData.donationAmount,
+      ]
+    );
+
+    const goalId = goalResult.insertId;
+
+    // Team_Goals 테이블에 추가 정보 삽입
+    const [teamGoalResult] = await connection.execute(
+      `
+      INSERT INTO Team_Goals (goal_id, time_attack, start_time, end_time)
+      VALUES (?, ?, ?, ?)
+    `,
+      [goalId, goalData.timeAttack, goalData.startTime, goalData.endTime]
+    );
+
+    // Team_Members 테이블에 팀원 정보 삽입
+    for (const memberId of goalData.teamMemberIds) {
+      await connection.execute(
+        `
+        INSERT INTO Team_Members (team_goal_id, user_id)
+        VALUES (?, ?)
+      `,
+        [teamGoalResult.insertId, memberId]
+      );
+    }
+
+    await connection.commit();
+    return { id: goalId, ...goalData };
+  } catch (err) {
+    await connection.rollback();
+    console.error('팀 목표 생성 중 에러 발생: ', err);
+    throw err;
+  } finally {
+    connection.release();
+  }
+};
+
+exports.createGoalRepeat = async (goalId, repeatData) => {
+  const query = `
+    INSERT INTO Goal_Repeats (goal_id, repeat_type, days_of_week, day_of_month, interval_of_days)
+    VALUES (?, ?, ?, ?, ?)
+  `;
+
+  const values = [
+    goalId,
+    repeatData.repeatType,
+    repeatData.daysOfWeek ? repeatData.daysOfWeek.join(',') : null,
+    repeatData.dayOfMonth || null,
+    repeatData.intervalOfDays || null,
+  ];
+
+  await pool.execute(query, values);
+};

--- a/src/routes/goal-route.js
+++ b/src/routes/goal-route.js
@@ -4,10 +4,14 @@ const { getWeeklyGoals } = require('../controllers/goal-controller');
 
 const { getUserGoals } = require('../controllers/goal-controller'); // 작성자: Minjae Han
 
+const { createGoal } = require('../controllers/goal-controller'); // 작성자: Minjae Han
+
 const goalRouter = express.Router();
 
 goalRouter.get('/week', getWeeklyGoals);
 
 goalRouter.get('/goals', getUserGoals); // 작성자: Minjae Han
+
+goalRouter.post('/goals', createGoal); // 작성자: Minjae Han
 
 module.exports = goalRouter;

--- a/src/services/goal-service.js
+++ b/src/services/goal-service.js
@@ -62,3 +62,26 @@ exports.getUserGoals = async (userId) => {
     throw error;
   }
 };
+
+// 작성자: Minjae Han
+
+const {
+  createPersonalGoal,
+  createTeamGoal,
+  createGoalRepeat,
+} = require('../models/goal-model');
+
+exports.createGoal = async (goalData) => {
+  let newGoal;
+  if (goalData.type === 'team') {
+    newGoal = await createTeamGoal(goalData);
+  } else {
+    newGoal = await createPersonalGoal(goalData);
+  }
+
+  if (goalData.repeatType) {
+    await createGoalRepeat(newGoal.id, goalData);
+  }
+
+  return newGoal;
+};

--- a/tests/goal-controller.test.js
+++ b/tests/goal-controller.test.js
@@ -1,4 +1,3 @@
-// ./tests/goal-controller.test.js
 // 작성자: Minjae Han
 
 const request = require('supertest');
@@ -7,6 +6,7 @@ const goalRouter = require('../src/routes/goal-route');
 const { StatusCodes } = require('http-status-codes');
 const {
   getUserGoals: mockGetUserGoals,
+  createGoal: mockCreateGoal,
 } = require('../src/services/goal-service');
 
 jest.mock('../src/services/goal-service');
@@ -57,6 +57,101 @@ describe('GET /goals', () => {
 
     const response = await request(app)
       .get('/goals')
+      .set('Authorization', 'Bearer fake-jwt-token');
+
+    expect(response.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.body.error).toBe('Internal Server Error');
+  });
+});
+
+describe('POST /goals', () => {
+  it('should create a personal goal', async () => {
+    const mockGoal = {
+      id: 1,
+      title: '달리기 챌린지',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+      type: 'personal',
+      validationType: 'photo',
+      latitude: 37.7749,
+      longitude: -122.4194,
+      emoji: '🏃',
+      donationOrganizationId: 1,
+      donationAmount: 1000,
+    };
+
+    mockCreateGoal.mockResolvedValue(mockGoal);
+
+    const response = await request(app)
+      .post('/goals')
+      .send(mockGoal)
+      .set('Authorization', 'Bearer fake-jwt-token');
+
+    expect(response.status).toBe(StatusCodes.CREATED);
+    expect(response.body).toEqual(expect.objectContaining(mockGoal));
+  });
+
+  it('should create a team goal with members', async () => {
+    const mockGoal = {
+      id: 2,
+      title: '팀 달리기 챌린지',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+      type: 'team',
+      validationType: 'team',
+      teamMemberIds: [2, 3, 4],
+      timeAttack: false,
+      startTime: '09:00:00',
+      endTime: '10:00:00',
+      repeatType: 'weekly',
+      daysOfWeek: ['mon', 'wed', 'fri'],
+    };
+
+    mockCreateGoal.mockResolvedValue(mockGoal);
+
+    const response = await request(app)
+      .post('/goals')
+      .send(mockGoal)
+      .set('Authorization', 'Bearer fake-jwt-token');
+
+    expect(response.status).toBe(StatusCodes.CREATED);
+    expect(response.body).toEqual(expect.objectContaining(mockGoal));
+  });
+
+  it('should return an error if required fields are missing', async () => {
+    const response = await request(app)
+      .post('/goals')
+      .send({
+        title: '', // Title is required, this should fail
+        startDate: '2024-01-01',
+        endDate: '2024-12-31',
+        type: 'personal',
+        validationType: 'photo',
+      })
+      .set('Authorization', 'Bearer fake-jwt-token');
+
+    expect(response.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(response.body).toEqual({
+      error: '유효하지 않은 요청입니다.',
+    });
+  });
+
+  it('should handle errors properly', async () => {
+    mockCreateGoal.mockRejectedValue(new Error('Something went wrong'));
+
+    const response = await request(app)
+      .post('/goals')
+      .send({
+        title: '팀 달리기 챌린지',
+        startDate: '2024-01-01',
+        endDate: '2024-12-31',
+        type: 'team',
+        validationType: 'team',
+        teamMemberIds: [2, 3, 4],
+        timeAttack: false,
+        startTime: '09:00:00',
+        endTime: '10:00:00',
+      })
       .set('Authorization', 'Bearer fake-jwt-token');
 
     expect(response.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
- 팀 목표를 생성할 수 있는 `POST /goals` API를 구현하였습니다.
- 목표 유형에 따라 개인 목표 또는 팀 목표로 데이터를 저장할 수 있도록 기능을 확장하였습니다.

### 주요 변경 사항
1. **팀 목표 생성 기능 추가**
   - 팀 목표 생성 시 `Goals` 테이블에 기본 정보 저장.
   - 팀 목표 관련 추가 정보를 `Team_Goals` 테이블에 저장.
   - `Team_Members` 테이블에 팀원 정보를 개별 행으로 저장.

2. **필수 필드 검증 추가**
   - 요청 시 필수 필드(`title`, `startDate`, `endDate`, `type`, `validationType`) 검증을 추가하여, 누락된 경우 `400 BAD REQUEST` 응답을 반환.

3. **반복 목표 기능 추가**
   - 반복 목표 설정에 따라 `Goal_Repeats` 테이블에 반복 정보를 저장.

4. **테스트 코드 추가**
   - `goal-controller.test.js`에 `POST /goals` API에 대한 테스트 케이스 추가.
   - 개인 목표 및 팀 목표 생성, 필수 필드 누락 시 오류 처리 등에 대한 테스트를 포함.

### 참고 사항
- PR이 머지되면, 관련 API 명세서 업데이트 및 배포가 필요합니다.
- 향후 추가적인 유효성 검사를 통해 사용자 경험을 개선할 예정입니다.